### PR TITLE
fix entitlements struct

### DIFF
--- a/crcauthlib.go
+++ b/crcauthlib.go
@@ -40,8 +40,8 @@ type Resp struct {
 }
 
 type Entitlement struct {
-	IsTrial   bool `json:"is_trial"`
-	IsEnabled bool `json:"is_enabled"`
+	IsTrial    bool `json:"is_trial"`
+	IsEntitled bool `json:"is_entitled"`
 }
 
 type XRHID struct {


### PR DESCRIPTION
Fix Entitlement struct to use "is_entitled" field to match keycloak attributes, and stage/prod structure.